### PR TITLE
Remove prophet in bigdl doc requirements and mock it instead

### DIFF
--- a/python-requirements/requirements-doc.txt
+++ b/python-requirements/requirements-doc.txt
@@ -23,7 +23,6 @@ recommonmark==0.5.0
 readthedocs-sphinx-ext<2.2
 scikit-learn==1.0.2
 pystan==2.19.1.1
-prophet==1.0.1
 pmdarima==1.8.5
 sphinx_markdown_tables==0.0.15
 numpy==1.21.2


### PR DESCRIPTION
Remove `prophet` in bigdl doc requirements and mock it instead as BigDL doc build failed https://readthedocs.org/projects/bigdl/builds/20161263/